### PR TITLE
feat: rebuild portfolio as Astro + Vercel site with scroll animations, Three.js hero, and D3 skills graph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ package-lock.json
 
 # Ignore folders related to IDEs
 .vscode/
+dist/
+.astro/

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,0 +1,12 @@
+import { defineConfig } from 'astro/config';
+import tailwind from '@astrojs/tailwind';
+import react from '@astrojs/react';
+
+export default defineConfig({
+  site: 'https://atreyanr.github.io',
+  integrations: [
+    tailwind({ applyBaseStyles: false }),
+    react(),
+  ],
+  output: 'static',
+});

--- a/package.json
+++ b/package.json
@@ -1,40 +1,29 @@
 {
-  "name": "academic-pages",
-  "version": "0.8.1.1",
-  "description": "Academic Pages Mistakes Jekyll theme npm build scripts",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/academicpages/academicpages.github.io"
-  },
-  "keywords": [
-    "jekyll",
-    "theme",
-    "minimal"
-  ],
-  "contributors": [
-    "Michael Rose",
-    "Robert Zupko"
-  ],
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/academicpages/academicpages.github.io/issues"
-  },
-  "homepage": "https://github.com/academicpages/academicpages.github.io",
-  "engines": {
-    "node": ">= 0.10.0"
+  "name": "atreyanr-portfolio",
+  "type": "module",
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview",
+    "check": "astro check"
   },
   "dependencies": {
-    "fitvids": "^2.1.1",
-    "jquery": "^3.7.1",
-    "jquery-smooth-scroll": "^2.2.0"
+    "@astrojs/react": "^3.6.0",
+    "@astrojs/tailwind": "^5.1.0",
+    "astro": "^4.16.0",
+    "d3": "^7.9.0",
+    "gsap": "^3.12.5",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "three": "^0.170.0"
   },
   "devDependencies": {
-    "onchange": "^7.1.0",
-    "uglify-js": "^3.17.4"
-  },
-  "scripts": {
-    "uglify": "uglifyjs node_modules/jquery/dist/jquery.min.js node_modules/fitvids/dist/fitvids.min.js node_modules/jquery-smooth-scroll/jquery.smooth-scroll.min.js assets/js/plugins/jquery.greedy-navigation.js assets/js/_main.js -c -m -o assets/js/main.min.js",
-    "watch:js": "onchange \"assets/js/**/*.js\" -e \"assets/js/main.min.js\" -- npm run build:js",
-    "build:js": "npm run uglify"
+    "@astrojs/check": "^0.9.8",
+    "@types/d3": "^7.4.3",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@types/three": "^0.170.0",
+    "tailwindcss": "^3.4.14",
+    "typescript": "^5.6.3"
   }
 }

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#FF6B35"/>
+  <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle" fill="white" font-size="18" font-weight="bold" font-family="sans-serif">A</text>
+</svg>

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -1,0 +1,33 @@
+---
+import { content } from '../../config/content';
+
+const { name, github, linkedin, email } = content.personal;
+
+const socialLinks = (
+  [
+    github   ? { href: `https://github.com/${github}`,        label: 'GitHub' }   : null,
+    linkedin ? { href: `https://linkedin.com/in/${linkedin}`, label: 'LinkedIn' } : null,
+    email    ? { href: `mailto:${email}`,                      label: 'Email' }    : null,
+  ] as const
+).filter((x): x is { href: string; label: string } => x !== null);
+---
+
+<footer class="border-t border-border mt-24">
+  <div class="max-w-6xl mx-auto px-6 py-10 flex flex-col md:flex-row items-center justify-between gap-4">
+    <p class="text-text-subtle text-sm">
+      © {new Date().getFullYear()} {name}. Built with Astro &amp; Vercel.
+    </p>
+    {socialLinks.length > 0 && (
+      <ul class="flex items-center gap-6">
+        {socialLinks.map(({ href, label }) => (
+          <li>
+            <a href={href} target="_blank" rel="noopener noreferrer"
+               class="text-text-muted hover:text-accent text-sm transition-colors">
+              {label}
+            </a>
+          </li>
+        ))}
+      </ul>
+    )}
+  </div>
+</footer>

--- a/src/components/layout/Navbar.astro
+++ b/src/components/layout/Navbar.astro
@@ -1,0 +1,69 @@
+---
+import { content } from '../../config/content';
+
+const navLinks = [
+  { href: '/projects',   label: 'Projects' },
+  { href: '/skills',     label: 'Skills' },
+  { href: '/experience', label: 'Experience' },
+  { href: '/blog',       label: 'Blog' },
+  { href: '/resume',     label: 'Resume' },
+];
+
+const [firstName, ...rest] = content.personal.name.split(' ');
+const lastName = rest.join(' ');
+---
+
+<header id="navbar" class="fixed top-0 left-0 right-0 z-50 glass transition-all duration-300">
+  <nav class="max-w-6xl mx-auto px-6 py-4 flex items-center justify-between">
+    <a href="/" class="font-bold text-text-primary hover:text-accent transition-colors text-lg tracking-tight">
+      {firstName}<span class="text-accent">&nbsp;{lastName}</span>
+    </a>
+
+    <ul class="hidden md:flex items-center gap-8">
+      {navLinks.map(({ href, label }) => (
+        <li>
+          <a href={href} class="nav-link text-sm text-text-muted hover:text-text-primary transition-colors">
+            {label}
+          </a>
+        </li>
+      ))}
+    </ul>
+
+    <button id="mobile-menu-toggle" class="md:hidden text-text-muted hover:text-text-primary" aria-label="Toggle menu">
+      <svg width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
+        <line x1="3" y1="6" x2="21" y2="6" />
+        <line x1="3" y1="12" x2="21" y2="12" />
+        <line x1="3" y1="18" x2="21" y2="18" />
+      </svg>
+    </button>
+  </nav>
+
+  <div id="mobile-menu" class="hidden md:hidden border-t border-border">
+    <ul class="max-w-6xl mx-auto px-6 py-4 flex flex-col gap-4">
+      {navLinks.map(({ href, label }) => (
+        <li>
+          <a href={href} class="nav-link text-text-muted hover:text-text-primary transition-colors block py-1">
+            {label}
+          </a>
+        </li>
+      ))}
+    </ul>
+  </div>
+</header>
+
+<script>
+  const navLinks = document.querySelectorAll('.nav-link');
+  const currentPath = window.location.pathname;
+  navLinks.forEach(link => {
+    const href = link.getAttribute('href');
+    if (href && href !== '/' && currentPath.startsWith(href)) {
+      link.classList.add('!text-accent');
+    }
+  });
+
+  const toggle = document.getElementById('mobile-menu-toggle');
+  const menu = document.getElementById('mobile-menu');
+  toggle?.addEventListener('click', () => {
+    menu?.classList.toggle('hidden');
+  });
+</script>

--- a/src/components/sections/About.astro
+++ b/src/components/sections/About.astro
@@ -1,0 +1,70 @@
+---
+import { content } from '../../config/content';
+
+const { bio } = content.personal;
+const { stats } = content;
+---
+
+<section id="about" class="py-32 max-w-6xl mx-auto px-6">
+  <div class="grid md:grid-cols-2 gap-16 items-center">
+    <div>
+      <p class="text-accent font-mono text-sm uppercase tracking-widest mb-4 reveal">About</p>
+      <h2 class="text-3xl md:text-4xl font-bold text-text-primary mb-6 reveal">
+        Building ML systems that<br/>
+        <span class="text-accent">actually ship.</span>
+      </h2>
+      <p class="text-text-muted leading-relaxed text-lg reveal">{bio}</p>
+    </div>
+
+    <div class="grid grid-cols-3 gap-6">
+      {stats.map((stat) => (
+        <div class="text-center p-6 rounded-xl bg-surface border border-border reveal">
+          <div class="text-4xl font-extrabold text-accent mb-1">
+            <span class="stat-value" data-target={stat.value}>0</span>{stat.suffix}
+          </div>
+          <div class="text-text-muted text-sm mt-1">{stat.label}</div>
+        </div>
+      ))}
+    </div>
+  </div>
+</section>
+
+<script>
+const gsap = (window as any).__gsap;
+const ScrollTrigger = (window as any).__ScrollTrigger;
+
+if (gsap && ScrollTrigger) {
+  // Reveal elements in the about section
+  gsap.utils.toArray<HTMLElement>('#about .reveal').forEach((el: HTMLElement) => {
+    gsap.from(el, {
+      y: 24,
+      opacity: 0,
+      duration: 0.6,
+      ease: 'power2.out',
+      scrollTrigger: {
+        trigger: el,
+        start: 'top 80%',
+      },
+    });
+  });
+
+  // Animated stat counters
+  document.querySelectorAll<HTMLElement>('.stat-value').forEach((el) => {
+    const target = parseInt(el.getAttribute('data-target') ?? '0', 10);
+    const obj = { val: 0 };
+    gsap.to(obj, {
+      val: target,
+      duration: 2,
+      ease: 'power2.out',
+      snap: { val: 1 },
+      scrollTrigger: {
+        trigger: el,
+        start: 'top 80%',
+      },
+      onUpdate() {
+        el.textContent = String(Math.round(obj.val));
+      },
+    });
+  });
+}
+</script>

--- a/src/components/sections/Hero.astro
+++ b/src/components/sections/Hero.astro
@@ -1,0 +1,213 @@
+---
+import { content } from '../../config/content';
+import { theme } from '../../config/theme';
+
+const { name, titles, resumePdf } = content.personal;
+const particleConfig = theme.particles;
+const accentColor = theme.colors.accent;
+const animConfig = theme.animation;
+---
+
+<section id="hero" class="relative min-h-screen flex items-center justify-center overflow-hidden pt-20">
+  <canvas id="hero-canvas" class="absolute inset-0 w-full h-full" style="z-index:0"></canvas>
+
+  <div class="absolute inset-0 bg-gradient-to-b from-background/10 via-background/30 to-background" style="z-index:1"></div>
+
+  <div class="relative z-10 max-w-4xl mx-auto px-6 text-center">
+    <p class="text-accent font-mono text-sm uppercase tracking-widest mb-4 reveal">
+      Hello, I&apos;m
+    </p>
+
+    <h1 class="text-5xl md:text-7xl font-extrabold text-text-primary mb-4 leading-tight reveal">
+      {name}
+    </h1>
+
+    <div class="h-12 mb-8 flex items-center justify-center reveal">
+      <span class="text-2xl md:text-3xl text-text-muted font-light">
+        <span id="typewriter" class="text-accent font-medium">{titles[0]}</span>
+      </span>
+    </div>
+
+    <div class="flex flex-col sm:flex-row gap-4 justify-center reveal">
+      <a href="/projects" class="btn-primary">View Projects</a>
+      <a href={resumePdf} target="_blank" rel="noopener noreferrer" class="btn-secondary">Resume</a>
+    </div>
+  </div>
+
+  <div id="scroll-indicator" class="absolute bottom-8 left-1/2 -translate-x-1/2 flex flex-col items-center gap-2 text-text-subtle">
+    <span class="text-xs uppercase tracking-widest font-mono">Scroll</span>
+    <div class="w-px h-12 bg-gradient-to-b from-text-subtle to-transparent animate-pulse"></div>
+  </div>
+</section>
+
+<script>
+import * as THREE from 'three';
+
+const canvas = document.getElementById('hero-canvas') as HTMLCanvasElement | null;
+if (!canvas) throw new Error('hero-canvas not found');
+
+const scene    = new THREE.Scene();
+const camera   = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+const renderer = new THREE.WebGLRenderer({ canvas, alpha: true, antialias: true });
+
+renderer.setSize(window.innerWidth, window.innerHeight);
+renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+camera.position.z = 300;
+
+const COUNT = 80;
+const SPEED = 0.3;
+const CONNECTION_DIST = 120;
+const MOUSE_INFLUENCE = 150;
+const ACCENT_COLOR = '#FF6B35';
+
+const positions = new Float32Array(COUNT * 3);
+const velocities: { x: number; y: number }[] = [];
+
+for (let i = 0; i < COUNT; i++) {
+  positions[i * 3]     = (Math.random() - 0.5) * window.innerWidth;
+  positions[i * 3 + 1] = (Math.random() - 0.5) * window.innerHeight;
+  positions[i * 3 + 2] = (Math.random() - 0.5) * 200;
+  velocities.push({
+    x: (Math.random() - 0.5) * SPEED,
+    y: (Math.random() - 0.5) * SPEED,
+  });
+}
+
+const pointsGeometry = new THREE.BufferGeometry();
+pointsGeometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+const pointsMaterial = new THREE.PointsMaterial({
+  size: 2,
+  color: ACCENT_COLOR,
+  transparent: true,
+  opacity: 0.6,
+});
+const points = new THREE.Points(pointsGeometry, pointsMaterial);
+scene.add(points);
+
+const lineMaterial = new THREE.LineBasicMaterial({
+  color: ACCENT_COLOR,
+  transparent: true,
+  opacity: 0.08,
+});
+let linesMesh: THREE.LineSegments | null = null;
+
+function buildLines(): void {
+  const linePositions: number[] = [];
+  for (let i = 0; i < COUNT; i++) {
+    for (let j = i + 1; j < COUNT; j++) {
+      const dx = positions[i * 3]     - positions[j * 3];
+      const dy = positions[i * 3 + 1] - positions[j * 3 + 1];
+      if (Math.sqrt(dx * dx + dy * dy) < CONNECTION_DIST) {
+        linePositions.push(
+          positions[i*3], positions[i*3+1], positions[i*3+2],
+          positions[j*3], positions[j*3+1], positions[j*3+2],
+        );
+      }
+    }
+  }
+  if (linesMesh) scene.remove(linesMesh);
+  const geo = new THREE.BufferGeometry();
+  geo.setAttribute('position', new THREE.Float32BufferAttribute(linePositions, 3));
+  linesMesh = new THREE.LineSegments(geo, lineMaterial);
+  scene.add(linesMesh);
+}
+
+let mouseX = 0;
+let mouseY = 0;
+window.addEventListener('mousemove', (e: MouseEvent) => {
+  mouseX =  (e.clientX - window.innerWidth  / 2);
+  mouseY = -(e.clientY - window.innerHeight / 2);
+});
+
+let frameCount = 0;
+function animate(): void {
+  requestAnimationFrame(animate);
+  frameCount++;
+
+  const hw = window.innerWidth  / 2;
+  const hh = window.innerHeight / 2;
+
+  for (let i = 0; i < COUNT; i++) {
+    positions[i * 3]     += velocities[i].x;
+    positions[i * 3 + 1] += velocities[i].y;
+
+    const dx = positions[i * 3]     - mouseX;
+    const dy = positions[i * 3 + 1] - mouseY;
+    const dist = Math.sqrt(dx * dx + dy * dy);
+    if (dist < MOUSE_INFLUENCE && dist > 0) {
+      const force = (MOUSE_INFLUENCE - dist) / MOUSE_INFLUENCE;
+      positions[i * 3]     += (dx / dist) * force * 2;
+      positions[i * 3 + 1] += (dy / dist) * force * 2;
+    }
+
+    if (positions[i * 3]     >  hw) positions[i * 3]     = -hw;
+    if (positions[i * 3]     < -hw) positions[i * 3]     =  hw;
+    if (positions[i * 3 + 1] >  hh) positions[i * 3 + 1] = -hh;
+    if (positions[i * 3 + 1] < -hh) positions[i * 3 + 1] =  hh;
+  }
+
+  pointsGeometry.attributes.position.needsUpdate = true;
+  if (frameCount % 3 === 0) buildLines();
+  renderer.render(scene, camera);
+}
+buildLines();
+animate();
+
+window.addEventListener('resize', () => {
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(window.innerWidth, window.innerHeight);
+});
+
+// Typewriter
+const twEl = document.getElementById('typewriter');
+const titles: string[] = ['Data Scientist', 'ML Engineer', 'Optimization Specialist'];
+if (twEl) {
+  let titleIndex = 0;
+  let charIndex  = 0;
+  let deleting   = false;
+
+  function type(): void {
+    const current = titles[titleIndex];
+    if (!deleting) {
+      twEl!.textContent = current.slice(0, charIndex + 1);
+      charIndex++;
+      if (charIndex === current.length) {
+        deleting = true;
+        setTimeout(type, 1800);
+        return;
+      }
+    } else {
+      twEl!.textContent = current.slice(0, charIndex - 1);
+      charIndex--;
+      if (charIndex === 0) {
+        deleting = false;
+        titleIndex = (titleIndex + 1) % titles.length;
+      }
+    }
+    setTimeout(type, deleting ? 50 : 90);
+  }
+  setTimeout(type, 800);
+}
+
+// Scroll indicator fade
+const indicator = document.getElementById('scroll-indicator');
+if (indicator) {
+  window.addEventListener('scroll', () => {
+    indicator.style.opacity = String(Math.max(0, 1 - window.scrollY / 200));
+  }, { passive: true });
+}
+
+// GSAP entrance animations
+const gsap = (window as any).__gsap;
+if (gsap) {
+  gsap.from('#hero .reveal', {
+    y: 30,
+    opacity: 0,
+    duration: 0.6,
+    stagger: 0.1,
+    ease: 'power2.out',
+    delay: 0.3,
+  });
+}
+</script>

--- a/src/components/ui/BlogCard.astro
+++ b/src/components/ui/BlogCard.astro
@@ -1,0 +1,27 @@
+---
+interface Props {
+  title: string;
+  date: string;
+  excerpt: string;
+  tags: string[];
+  slug: string;
+  readingTime?: number;
+}
+
+const { title, date, excerpt, tags, slug, readingTime = 3 } = Astro.props;
+---
+
+<article class="group p-6 rounded-xl bg-surface border border-border hover:border-accent/30 transition-all duration-300">
+  <div class="flex items-center gap-3 mb-3 text-xs text-text-subtle font-mono">
+    <time datetime={date}>{date}</time>
+    <span aria-hidden="true">·</span>
+    <span>{readingTime} min read</span>
+  </div>
+  <h2 class="text-text-primary font-semibold text-xl mb-2 group-hover:text-accent transition-colors">
+    <a href={`/blog/${slug}`} class="outline-none focus:underline">{title}</a>
+  </h2>
+  <p class="text-text-muted text-sm leading-relaxed mb-4">{excerpt}</p>
+  <div class="flex flex-wrap gap-2">
+    {tags.map(tag => <span class="tag">{tag}</span>)}
+  </div>
+</article>

--- a/src/components/ui/ProjectCard.astro
+++ b/src/components/ui/ProjectCard.astro
@@ -1,0 +1,50 @@
+---
+interface Props {
+  title: string;
+  description: string;
+  tags: readonly string[];
+  link: string;
+  image: string | null;
+  featured?: boolean;
+}
+
+const { title, description, tags, link, image, featured = false } = Astro.props;
+---
+
+<article
+  class:list={[
+    'group relative rounded-xl bg-surface border border-border overflow-hidden',
+    'hover:border-accent/30 transition-all duration-300',
+  ]}
+>
+  <div class:list={['relative overflow-hidden', featured ? 'h-48' : 'h-32']}>
+    {image
+      ? <img src={image} alt={title} class="w-full h-full object-cover group-hover:scale-105 transition-transform duration-500" />
+      : <div class="w-full h-full bg-gradient-to-br from-accent/20 to-surface-hover" />
+    }
+    {featured && (
+      <span class="absolute top-3 left-3 z-10 text-xs font-mono font-medium px-2 py-0.5 rounded-full bg-accent text-white">
+        Featured
+      </span>
+    )}
+    <div class="absolute inset-0 bg-background/90 opacity-0 group-hover:opacity-100 transition-opacity duration-300 flex flex-wrap items-center justify-center gap-2 p-4">
+      {tags.map(tag => <span class="tag">{tag}</span>)}
+    </div>
+  </div>
+
+  <div class="p-6">
+    <h3 class="text-text-primary font-semibold text-lg mb-2">{title}</h3>
+    <p class="text-text-muted text-sm leading-relaxed mb-4">{description}</p>
+    <a
+      href={link}
+      target="_blank"
+      rel="noopener noreferrer"
+      class="text-accent text-sm font-medium hover:underline inline-flex items-center gap-1"
+    >
+      View Project
+      <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5">
+        <path d="M2 10L10 2M10 2H5M10 2V7"/>
+      </svg>
+    </a>
+  </div>
+</article>

--- a/src/components/ui/SkillGraph.tsx
+++ b/src/components/ui/SkillGraph.tsx
@@ -1,0 +1,189 @@
+import * as d3 from 'd3';
+import { useEffect, useRef, useState } from 'react';
+
+interface Skill {
+  name: string;
+  category: string;
+  proficiency: number;
+  tools: readonly string[];
+}
+
+interface Props {
+  skills: Skill[];
+  categoryColors: Record<string, string>;
+}
+
+interface SimNode extends d3.SimulationNodeDatum {
+  id: string;
+  skill: Skill;
+}
+
+interface TooltipState {
+  x: number;
+  y: number;
+  skill: Skill;
+  color: string;
+}
+
+export default function SkillGraph({ skills, categoryColors }: Props) {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const [tooltip, setTooltip] = useState<TooltipState | null>(null);
+  const [dimensions, setDimensions] = useState({ width: 800, height: 500 });
+
+  useEffect(() => {
+    const update = () => {
+      const parent = svgRef.current?.parentElement;
+      if (parent) {
+        setDimensions({
+          width: parent.clientWidth,
+          height: Math.min(parent.clientWidth * 0.65, 600),
+        });
+      }
+    };
+    update();
+    window.addEventListener('resize', update);
+    return () => window.removeEventListener('resize', update);
+  }, []);
+
+  useEffect(() => {
+    const { width, height } = dimensions;
+    const svg = d3.select(svgRef.current);
+    svg.selectAll('*').remove();
+
+    const nodes: SimNode[] = skills.map(s => ({ id: s.name, skill: s }));
+
+    const centroids: Record<string, { x: number; y: number }> = {
+      'ML Models':    { x: width * 0.28, y: height * 0.32 },
+      'Optimization': { x: width * 0.72, y: height * 0.32 },
+      'NLP / RAG':    { x: width * 0.72, y: height * 0.70 },
+      'Data & SQL':   { x: width * 0.28, y: height * 0.70 },
+    };
+
+    function clusterForce(alpha: number): void {
+      nodes.forEach(node => {
+        const centroid = centroids[node.skill.category];
+        if (!centroid) return;
+        node.vx = (node.vx ?? 0) + (centroid.x - (node.x ?? 0)) * alpha * 0.4;
+        node.vy = (node.vy ?? 0) + (centroid.y - (node.y ?? 0)) * alpha * 0.4;
+      });
+    }
+    (clusterForce as any).initialize = () => {};
+
+    const simulation = d3
+      .forceSimulation<SimNode>(nodes)
+      .force('charge', d3.forceManyBody<SimNode>().strength(-80))
+      .force('collision', d3.forceCollide<SimNode>(d => d.skill.proficiency * 30 + 12))
+      .force('cluster', clusterForce as any)
+      .on('tick', ticked);
+
+    // Category labels
+    const labelG = svg.append('g');
+    Object.entries(centroids).forEach(([cat, pos]) => {
+      const color = categoryColors[cat];
+      labelG.append('text')
+        .attr('x', pos.x)
+        .attr('y', pos.y - 30)
+        .attr('text-anchor', 'middle')
+        .attr('fill', color ?? '#888')
+        .attr('font-size', '11px')
+        .attr('font-family', 'JetBrains Mono, monospace')
+        .attr('font-weight', '500')
+        .attr('letter-spacing', '0.1em')
+        .attr('opacity', 0.6)
+        .text(cat.toUpperCase());
+    });
+
+    // Node circles
+    const nodeG = svg.append('g');
+    const circles = nodeG
+      .selectAll('circle')
+      .data(nodes)
+      .join('circle')
+      .attr('r', d => d.skill.proficiency * 28 + 8)
+      .attr('fill', d => (categoryColors[d.skill.category] ?? '#888') + '22')
+      .attr('stroke', d => categoryColors[d.skill.category] ?? '#888')
+      .attr('stroke-width', 1.5)
+      .attr('cursor', 'pointer')
+      .on('mouseenter', (event: MouseEvent, d: SimNode) => {
+        d3.select(event.currentTarget as Element)
+          .attr('fill', (categoryColors[d.skill.category] ?? '#888') + '55');
+        const rect = svgRef.current!.getBoundingClientRect();
+        setTooltip({
+          x: event.clientX - rect.left,
+          y: event.clientY - rect.top,
+          skill: d.skill,
+          color: categoryColors[d.skill.category] ?? '#888',
+        });
+      })
+      .on('mouseleave', (event: MouseEvent, d: SimNode) => {
+        d3.select(event.currentTarget as Element)
+          .attr('fill', (categoryColors[d.skill.category] ?? '#888') + '22');
+        setTooltip(null);
+      });
+
+    // Node labels
+    const labels = nodeG
+      .selectAll('text')
+      .data(nodes)
+      .join('text')
+      .attr('text-anchor', 'middle')
+      .attr('dominant-baseline', 'middle')
+      .attr('fill', d => categoryColors[d.skill.category] ?? '#888')
+      .attr('font-size', d => Math.max(9, d.skill.proficiency * 11))
+      .attr('font-family', 'Inter, sans-serif')
+      .attr('pointer-events', 'none')
+      .text(d => d.id);
+
+    function ticked(): void {
+      circles.attr('cx', d => d.x ?? 0).attr('cy', d => d.y ?? 0);
+      labels.attr('x',  d => d.x ?? 0).attr('y',  d => d.y ?? 0);
+    }
+
+    const cooldownTimer = setTimeout(() => simulation.alphaTarget(0), 3000);
+    return () => {
+      clearTimeout(cooldownTimer);
+      simulation.stop();
+    };
+  }, [skills, categoryColors, dimensions]);
+
+  return (
+    <div style={{ position: 'relative', width: '100%', height: dimensions.height }}>
+      <svg ref={svgRef} width={dimensions.width} height={dimensions.height} />
+
+      {tooltip && (
+        <div
+          style={{
+            position: 'absolute',
+            left: tooltip.x + 12,
+            top: tooltip.y - 12,
+            background: '#12121A',
+            border: `1px solid ${tooltip.color}40`,
+            borderRadius: 8,
+            padding: '10px 12px',
+            minWidth: 160,
+            pointerEvents: 'none',
+            zIndex: 10,
+          }}
+        >
+          <div style={{ color: tooltip.color, fontWeight: 600, marginBottom: 4 }}>
+            {tooltip.skill.name}
+          </div>
+          <div style={{ color: '#8888A0', fontSize: 11, marginBottom: 8 }}>
+            {tooltip.skill.category}
+          </div>
+          <div style={{ height: 4, borderRadius: 2, background: '#1E1E2E', marginBottom: 8 }}>
+            <div style={{
+              height: 4,
+              borderRadius: 2,
+              width: `${tooltip.skill.proficiency * 100}%`,
+              background: tooltip.color,
+            }} />
+          </div>
+          <div style={{ color: '#555568', fontSize: 10 }}>
+            {tooltip.skill.tools.join(' · ')}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ui/Timeline.astro
+++ b/src/components/ui/Timeline.astro
@@ -1,0 +1,47 @@
+---
+import { content } from '../../config/content';
+---
+
+<div class="timeline-container relative">
+  <!-- Vertical center line (desktop only) -->
+  <div class="hidden md:block absolute left-1/2 -translate-x-px top-0 bottom-0 w-px bg-border" aria-hidden="true">
+    <div id="timeline-progress" class="w-full bg-accent" style="height: 0%; transition: none;"></div>
+  </div>
+
+  <div class="flex flex-col gap-16">
+    {content.experience.map((entry, i) => (
+      <div
+        class="timeline-entry relative grid md:grid-cols-2 gap-8 items-start"
+        data-index={i}
+      >
+        <!-- Dot on the center line -->
+        <div class="hidden md:block absolute left-1/2 -translate-x-1/2 w-3 h-3 rounded-full bg-accent border-2 border-background mt-6 z-10" />
+
+        <!-- Content card — alternates sides on desktop -->
+        <div class:list={[
+          'p-6 rounded-xl bg-surface border border-border hover:border-accent/30 transition-colors duration-300',
+          i % 2 === 0 ? 'md:col-start-1' : 'md:col-start-2',
+        ]}>
+          <div class="flex items-start justify-between gap-4 mb-4 flex-wrap">
+            <div>
+              <h3 class="text-text-primary font-semibold text-xl">{entry.role}</h3>
+              <p class="text-accent text-sm font-medium mt-0.5">{entry.company}</p>
+            </div>
+            <span class="text-text-subtle text-sm font-mono whitespace-nowrap">
+              {entry.start} — {entry.end}
+            </span>
+          </div>
+          <p class="text-text-muted text-sm leading-relaxed mb-4">{entry.description}</p>
+          <ul class="flex flex-col gap-2">
+            {entry.highlights.map(h => (
+              <li class="flex gap-2 text-sm text-text-muted">
+                <span class="text-accent shrink-0 mt-0.5">›</span>
+                <span>{h}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    ))}
+  </div>
+</div>

--- a/src/config/content.ts
+++ b/src/config/content.ts
@@ -1,0 +1,72 @@
+// ============================================================
+// CONTENT CONFIGURATION
+// Edit this file to update all personal data on the site.
+// No HTML files need to be touched to add projects/experience.
+// ============================================================
+
+export const content = {
+  personal: {
+    name: 'Atreyan Raman',
+    titles: ['Data Scientist', 'ML Engineer', 'Optimization Specialist'],
+    bio: 'Data Scientist specializing in machine learning, combinatorial optimization, and AI systems. I build models that go to production and solutions that move the needle on real business problems.',
+    location: 'San Francisco, CA',
+    email: '',
+    github: '',
+    linkedin: '',
+    resumePdf: '/resume.pdf',
+  },
+
+  stats: [
+    { value: 10, suffix: '+', label: 'Projects Shipped' },
+    { value: 5,  suffix: '+', label: 'Models in Production' },
+    { value: 3,  suffix: '+', label: 'Years Experience' },
+  ],
+
+  skills: [
+    { name: 'Python',                    category: 'Data & SQL',    proficiency: 0.95, tools: ['pandas', 'numpy', 'polars', 'FastAPI'] },
+    { name: 'SQL',                       category: 'Data & SQL',    proficiency: 0.90, tools: ['PostgreSQL', 'BigQuery', 'dbt', 'Snowflake'] },
+    { name: 'pandas',                    category: 'Data & SQL',    proficiency: 0.95, tools: ['GroupBy', 'Merge', 'Pivot', 'Time Series'] },
+    { name: 'Data Pipelines',            category: 'Data & SQL',    proficiency: 0.80, tools: ['Airflow', 'dbt', 'Spark', 'Prefect'] },
+    { name: 'CatBoost',                  category: 'ML Models',     proficiency: 0.90, tools: ['optuna', 'cross-validation', 'feature importance'] },
+    { name: 'SHAP',                      category: 'ML Models',     proficiency: 0.85, tools: ['TreeExplainer', 'summary_plot', 'force_plot'] },
+    { name: 'scikit-learn',              category: 'ML Models',     proficiency: 0.90, tools: ['Pipeline', 'GridSearchCV', 'cross_val_score'] },
+    { name: 'Mixed Integer Programming', category: 'Optimization',  proficiency: 0.85, tools: ['PuLP', 'Gurobi', 'OR-Tools', 'CPLEX'] },
+    { name: 'PuLP',                      category: 'Optimization',  proficiency: 0.85, tools: ['LpProblem', 'LpVariable', 'CBC solver'] },
+    { name: 'RAG Pipelines',             category: 'NLP / RAG',     proficiency: 0.80, tools: ['LangChain', 'LlamaIndex', 'FAISS'] },
+    { name: 'LangChain',                 category: 'NLP / RAG',     proficiency: 0.75, tools: ['LCEL', 'Agents', 'Retrieval chains'] },
+    { name: 'Vector Databases',          category: 'NLP / RAG',     proficiency: 0.75, tools: ['Chroma', 'Pinecone', 'Weaviate', 'pgvector'] },
+  ],
+
+  skillCategories: {
+    'ML Models':    '#FF6B35',
+    'Optimization': '#22D3A5',
+    'NLP / RAG':    '#A78BFA',
+    'Data & SQL':   '#60A5FA',
+  },
+
+  projects: [
+    {
+      title: 'Project Title',
+      description: 'Short description of the project. What problem did it solve? What impact did it have?',
+      tags: ['Python', 'CatBoost', 'SHAP'],
+      link: '#',
+      image: null as string | null,
+      featured: true,
+    },
+  ],
+
+  experience: [
+    {
+      company: 'Company Name',
+      role: 'Data Scientist',
+      start: 'Jan 2023',
+      end: 'Present',
+      description: 'Brief description of the role and team context.',
+      highlights: [
+        'Built and deployed an ML model that improved X by Y%',
+        'Led data science workstream for Z initiative',
+        'Optimized supply chain allocation using MIP, reducing costs by $Xk',
+      ],
+    },
+  ],
+} as const;

--- a/src/config/theme.ts
+++ b/src/config/theme.ts
@@ -1,0 +1,56 @@
+// ============================================================
+// THEME CONFIGURATION
+// Edit this file to change all visual settings site-wide.
+// Colors here feed into tailwind.config.ts automatically.
+// ============================================================
+
+export const theme = {
+  colors: {
+    // Page backgrounds
+    background: '#0A0A0F',
+    surface: '#12121A',
+    surfaceHover: '#1A1A24',
+    surfaceBorder: '#1E1E2E',
+
+    // Accent — change this one value to re-theme the whole site
+    accent: '#FF6B35',
+    accentHover: '#FF8C5A',
+    accentMuted: 'rgba(255, 107, 53, 0.12)',
+
+    // Text
+    textPrimary: '#E8E8F0',
+    textMuted: '#8888A0',
+    textSubtle: '#555568',
+
+    // Semantic
+    success: '#22D3A5',
+    warning: '#F5A623',
+    error: '#FF4B6E',
+  },
+
+  fonts: {
+    sans: '"Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+    mono: '"JetBrains Mono", "Fira Code", "Cascadia Code", monospace',
+  },
+
+  // Controls all GSAP scroll animations — change here, applies everywhere
+  animation: {
+    duration: 0.6,
+    stagger: 0.1,
+    ease: 'power2.out',
+    scrubSpeed: 1,
+    triggerOffset: '80%',
+    counterDuration: 2,
+  },
+
+  // Three.js hero particle mesh
+  particles: {
+    count: 80,
+    size: 2,
+    connectionDistance: 120,
+    mouseInfluence: 150,
+    speed: 0.3,
+  },
+} as const;
+
+export type Theme = typeof theme;

--- a/src/content/blog/hello-world.md
+++ b/src/content/blog/hello-world.md
@@ -1,0 +1,11 @@
+---
+title: "Hello World"
+date: "2026-03-28"
+excerpt: "First post on the new portfolio — more to come on data science, optimization, and ML systems."
+tags: ["meta"]
+draft: false
+---
+
+Welcome to my portfolio blog. I'll be writing about data science, combinatorial optimization, RAG pipelines, and building ML systems that actually ship.
+
+Stay tuned.

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,0 +1,14 @@
+import { defineCollection, z } from 'astro:content';
+
+const blog = defineCollection({
+  type: 'content',
+  schema: z.object({
+    title: z.string(),
+    date: z.string(),
+    excerpt: z.string(),
+    tags: z.array(z.string()).default([]),
+    draft: z.boolean().default(false),
+  }),
+});
+
+export const collections = { blog };

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,1 @@
+/// <reference path="../.astro/types.d.ts" />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,0 +1,47 @@
+---
+import '../styles/global.css';
+import Navbar from '../components/layout/Navbar.astro';
+import Footer from '../components/layout/Footer.astro';
+import { content } from '../config/content';
+
+interface Props {
+  title?: string;
+  description?: string;
+}
+
+const {
+  title = content.personal.name,
+  description = content.personal.bio,
+} = Astro.props;
+---
+
+<!doctype html>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content={description} />
+    <title>{title} | {content.personal.name}</title>
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  </head>
+  <body>
+    <Navbar />
+    <main>
+      <slot />
+    </main>
+    <Footer />
+
+    <script>
+      import { gsap } from 'gsap';
+      import { ScrollTrigger } from 'gsap/ScrollTrigger';
+      gsap.registerPlugin(ScrollTrigger);
+      (window as any).__gsap = gsap;
+      (window as any).__ScrollTrigger = ScrollTrigger;
+    </script>
+  </body>
+</html>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,0 +1,55 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import { getCollection } from 'astro:content';
+import type { CollectionEntry } from 'astro:content';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog');
+  return posts.map(post => ({
+    params: { slug: post.slug },
+    props: { post },
+  }));
+}
+
+interface Props {
+  post: CollectionEntry<'blog'>;
+}
+
+const { post } = Astro.props;
+if (!post) return Astro.redirect('/blog');
+
+const { Content } = await post.render();
+---
+
+<Layout title={post.data.title} description={post.data.excerpt}>
+  <article class="min-h-screen pt-32 pb-24 max-w-3xl mx-auto px-6">
+    <header class="mb-12">
+      <div class="flex items-center gap-3 mb-6 text-xs text-text-subtle font-mono">
+        <a href="/blog" class="hover:text-accent transition-colors">← Blog</a>
+        <span>·</span>
+        <time datetime={post.data.date}>{post.data.date}</time>
+      </div>
+      <h1 class="text-4xl md:text-5xl font-bold text-text-primary mb-6 leading-tight">
+        {post.data.title}
+      </h1>
+      <div class="flex flex-wrap gap-2">
+        {post.data.tags.map((tag: string) => <span class="tag">{tag}</span>)}
+      </div>
+    </header>
+
+    <div class="prose-dark">
+      <Content />
+    </div>
+  </article>
+</Layout>
+
+<style>
+  .prose-dark :global(h2)         { @apply text-2xl font-bold text-text-primary mt-10 mb-4; }
+  .prose-dark :global(h3)         { @apply text-xl font-semibold text-text-primary mt-8 mb-3; }
+  .prose-dark :global(p)          { @apply text-text-muted leading-relaxed mb-4; }
+  .prose-dark :global(a)          { @apply text-accent hover:underline; }
+  .prose-dark :global(code)       { @apply font-mono text-sm bg-surface px-1.5 py-0.5 rounded text-accent; }
+  .prose-dark :global(pre)        { @apply bg-surface border border-border rounded-xl p-4 overflow-x-auto mb-6; }
+  .prose-dark :global(ul)         { @apply list-disc list-inside text-text-muted mb-4 space-y-1; }
+  .prose-dark :global(blockquote) { @apply border-l-2 border-accent pl-4 italic text-text-muted my-6; }
+</style>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,0 +1,50 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import BlogCard from '../../components/ui/BlogCard.astro';
+import { getCollection } from 'astro:content';
+
+const posts = (await getCollection('blog', entry => !entry.data.draft))
+  .sort((a, b) => new Date(b.data.date).valueOf() - new Date(a.data.date).valueOf());
+---
+
+<Layout title="Blog">
+  <div class="min-h-screen pt-32 pb-24 max-w-4xl mx-auto px-6">
+    <div class="mb-12">
+      <p class="text-accent font-mono text-sm uppercase tracking-widest mb-3 reveal">Writing</p>
+      <h1 class="text-4xl md:text-5xl font-bold text-text-primary reveal">Blog</h1>
+    </div>
+
+    {posts.length === 0 ? (
+      <p class="text-text-muted text-lg">No posts yet — check back soon.</p>
+    ) : (
+      <div class="flex flex-col gap-6">
+        {posts.map(post => (
+          <div class="reveal">
+            <BlogCard
+              title={post.data.title}
+              date={post.data.date}
+              excerpt={post.data.excerpt}
+              tags={post.data.tags}
+              slug={post.slug}
+            />
+          </div>
+        ))}
+      </div>
+    )}
+  </div>
+</Layout>
+
+<script>
+const gsap = (window as any).__gsap;
+if (gsap) {
+  gsap.utils.toArray<HTMLElement>('.reveal').forEach((el: HTMLElement) => {
+    gsap.from(el, {
+      y: 24,
+      opacity: 0,
+      duration: 0.6,
+      ease: 'power2.out',
+      scrollTrigger: { trigger: el, start: 'top 80%' },
+    });
+  });
+}
+</script>

--- a/src/pages/experience.astro
+++ b/src/pages/experience.astro
@@ -1,0 +1,67 @@
+---
+import Layout from '../layouts/Layout.astro';
+import Timeline from '../components/ui/Timeline.astro';
+---
+
+<Layout title="Experience">
+  <div class="min-h-screen pt-32 pb-24 max-w-5xl mx-auto px-6">
+    <div class="mb-16">
+      <p class="text-accent font-mono text-sm uppercase tracking-widest mb-3 reveal">Career</p>
+      <h1 class="text-4xl md:text-5xl font-bold text-text-primary reveal">Experience</h1>
+    </div>
+
+    <Timeline />
+  </div>
+</Layout>
+
+<script>
+const gsap = (window as any).__gsap;
+const ScrollTrigger = (window as any).__ScrollTrigger;
+
+if (gsap && ScrollTrigger) {
+  // Reveal header elements
+  gsap.utils.toArray<HTMLElement>('.reveal').forEach((el: HTMLElement) => {
+    gsap.from(el, {
+      y: 24,
+      opacity: 0,
+      duration: 0.6,
+      ease: 'power2.out',
+      scrollTrigger: { trigger: el, start: 'top 80%' },
+    });
+  });
+
+  // Animate the timeline progress bar as you scroll
+  const progressBar = document.getElementById('timeline-progress');
+  const container   = document.querySelector('.timeline-container');
+
+  if (progressBar && container) {
+    gsap.to(progressBar, {
+      height: '100%',
+      ease: 'none',
+      scrollTrigger: {
+        trigger: container,
+        start: 'top 80%',
+        end: 'bottom 20%',
+        scrub: 1,
+      },
+    });
+  }
+
+  // Slide in timeline entry cards from alternating sides
+  gsap.utils.toArray<HTMLElement>('.timeline-entry').forEach((entry: HTMLElement) => {
+    const index = parseInt(entry.getAttribute('data-index') ?? '0', 10);
+    const card  = entry.querySelector<HTMLElement>('.p-6');
+    if (!card) return;
+    gsap.from(card, {
+      x: window.innerWidth >= 768 ? (index % 2 === 0 ? -40 : 40) : -40,
+      opacity: 0,
+      duration: 0.7,
+      ease: 'power2.out',
+      scrollTrigger: {
+        trigger: entry,
+        start: 'top 80%',
+      },
+    });
+  });
+}
+</script>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,0 +1,11 @@
+---
+import Layout from '../layouts/Layout.astro';
+import Hero from '../components/sections/Hero.astro';
+import About from '../components/sections/About.astro';
+import { content } from '../config/content';
+---
+
+<Layout title="Portfolio" description={content.personal.bio}>
+  <Hero />
+  <About />
+</Layout>

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -1,0 +1,84 @@
+---
+import Layout from '../layouts/Layout.astro';
+import ProjectCard from '../components/ui/ProjectCard.astro';
+import { content } from '../config/content';
+
+const allTags = [...new Set(content.projects.flatMap(p => [...p.tags]))].sort();
+---
+
+<Layout title="Projects">
+  <div class="min-h-screen pt-32 pb-24 max-w-6xl mx-auto px-6">
+    <div class="mb-12">
+      <p class="text-accent font-mono text-sm uppercase tracking-widest mb-3 reveal">Work</p>
+      <h1 class="text-4xl md:text-5xl font-bold text-text-primary reveal">Projects</h1>
+    </div>
+
+    <div id="tag-filters" class="flex flex-wrap gap-2 mb-10 reveal">
+      <button class="filter-btn active-filter tag" data-tag="all">All</button>
+      {allTags.map(tag => (
+        <button class="filter-btn tag" data-tag={tag}>{tag}</button>
+      ))}
+    </div>
+
+    <div id="project-grid" class="grid grid-cols-1 md:grid-cols-3 gap-6">
+      {content.projects.map(project => (
+        <div
+          class:list={['project-item', project.featured ? 'md:col-span-2' : '']}
+          data-tags={JSON.stringify([...project.tags])}
+        >
+          <ProjectCard {...project} />
+        </div>
+      ))}
+    </div>
+  </div>
+</Layout>
+
+<style>
+  .active-filter {
+    background-color: theme('colors.accent') !important;
+    color: white !important;
+    border-color: theme('colors.accent') !important;
+  }
+</style>
+
+<script>
+const gsap = (window as any).__gsap;
+const ScrollTrigger = (window as any).__ScrollTrigger;
+
+if (gsap && ScrollTrigger) {
+  gsap.utils.toArray<HTMLElement>('.reveal').forEach((el: HTMLElement) => {
+    gsap.from(el, {
+      y: 24,
+      opacity: 0,
+      duration: 0.6,
+      ease: 'power2.out',
+      scrollTrigger: { trigger: el, start: 'top 80%' },
+    });
+  });
+
+  gsap.from('.project-item', {
+    y: 32,
+    opacity: 0,
+    duration: 0.6,
+    stagger: 0.1,
+    ease: 'power2.out',
+    delay: 0.2,
+  });
+}
+
+// Tag filtering
+const filterBtns = document.querySelectorAll<HTMLButtonElement>('.filter-btn');
+const items = document.querySelectorAll<HTMLElement>('.project-item');
+
+filterBtns.forEach(btn => {
+  btn.addEventListener('click', () => {
+    const tag = btn.getAttribute('data-tag');
+    filterBtns.forEach(b => b.classList.remove('active-filter'));
+    btn.classList.add('active-filter');
+    items.forEach(item => {
+      const tags: string[] = JSON.parse(item.getAttribute('data-tags') ?? '[]');
+      item.style.display = (tag === 'all' || tags.includes(tag ?? '')) ? '' : 'none';
+    });
+  });
+});
+</script>

--- a/src/pages/resume.astro
+++ b/src/pages/resume.astro
@@ -1,0 +1,52 @@
+---
+import Layout from '../layouts/Layout.astro';
+import { content } from '../config/content';
+---
+
+<Layout title="Resume">
+  <div class="min-h-screen pt-32 pb-24 max-w-5xl mx-auto px-6">
+    <div class="flex items-center justify-between mb-8 flex-wrap gap-4">
+      <div>
+        <p class="text-accent font-mono text-sm uppercase tracking-widest mb-2 reveal">CV</p>
+        <h1 class="text-4xl font-bold text-text-primary reveal">Resume</h1>
+      </div>
+      <a
+        href={content.personal.resumePdf}
+        download
+        class="btn-primary reveal"
+      >
+        Download PDF
+      </a>
+    </div>
+
+    <div class="rounded-xl overflow-hidden border border-border reveal">
+      <embed
+        src={content.personal.resumePdf}
+        type="application/pdf"
+        class="w-full"
+        style="height: 85vh; min-height: 600px;"
+      />
+    </div>
+
+    <p class="text-text-subtle text-sm mt-4 text-center md:hidden">
+      PDF viewer not available on mobile?
+      <a href={content.personal.resumePdf} target="_blank" rel="noopener noreferrer" class="text-accent hover:underline">
+        Open in new tab
+      </a>
+    </p>
+  </div>
+</Layout>
+
+<script>
+const gsap = (window as any).__gsap;
+if (gsap) {
+  gsap.from('.reveal', {
+    y: 24,
+    opacity: 0,
+    duration: 0.6,
+    ease: 'power2.out',
+    stagger: 0.1,
+    delay: 0.2,
+  });
+}
+</script>

--- a/src/pages/skills.astro
+++ b/src/pages/skills.astro
@@ -1,0 +1,58 @@
+---
+import Layout from '../layouts/Layout.astro';
+import SkillGraph from '../components/ui/SkillGraph.tsx';
+import { content } from '../config/content';
+
+// Convert readonly arrays/objects to mutable for React prop passing
+const skills = content.skills.map(s => ({
+  name: s.name,
+  category: s.category,
+  proficiency: s.proficiency,
+  tools: [...s.tools],
+}));
+const categoryColors = { ...content.skillCategories };
+---
+
+<Layout title="Skills">
+  <div class="min-h-screen pt-32 pb-24 max-w-6xl mx-auto px-6">
+    <div class="mb-12">
+      <p class="text-accent font-mono text-sm uppercase tracking-widest mb-3 reveal">Capabilities</p>
+      <h1 class="text-4xl md:text-5xl font-bold text-text-primary reveal">Skills</h1>
+      <p class="text-text-muted mt-4 text-lg reveal">
+        Hover any node to see tools and proficiency. Clusters group related skills.
+      </p>
+    </div>
+
+    <div class="bg-surface rounded-2xl border border-border p-6 reveal">
+      <SkillGraph
+        client:only="react"
+        skills={skills}
+        categoryColors={categoryColors}
+      />
+    </div>
+
+    <div class="flex flex-wrap gap-6 mt-6 reveal">
+      {Object.entries(content.skillCategories).map(([cat, color]) => (
+        <div class="flex items-center gap-2">
+          <span class="w-3 h-3 rounded-full inline-block" style={`background:${color}`}></span>
+          <span class="text-text-muted text-sm">{cat}</span>
+        </div>
+      ))}
+    </div>
+  </div>
+</Layout>
+
+<script>
+const gsap = (window as any).__gsap;
+if (gsap) {
+  gsap.utils.toArray<HTMLElement>('.reveal').forEach((el: HTMLElement) => {
+    gsap.from(el, {
+      y: 24,
+      opacity: 0,
+      duration: 0.6,
+      ease: 'power2.out',
+      scrollTrigger: { trigger: el, start: 'top 80%' },
+    });
+  });
+}
+</script>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,0 +1,66 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    color-scheme: dark;
+  }
+
+  html {
+    scroll-behavior: smooth;
+  }
+
+  body {
+    @apply bg-background text-text-primary font-sans;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  ::selection {
+    background-color: theme('colors.accent');
+    color: white;
+  }
+
+  ::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  ::-webkit-scrollbar-track {
+    @apply bg-background;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    @apply bg-border rounded-full;
+  }
+
+  ::-webkit-scrollbar-thumb:hover {
+    @apply bg-text-subtle;
+  }
+}
+
+@layer components {
+  .glass {
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    background: rgba(10, 10, 15, 0.8);
+    border-bottom: 1px solid rgba(30, 30, 46, 0.8);
+  }
+
+  .reveal {
+    opacity: 0;
+    transform: translateY(24px);
+  }
+
+  .tag {
+    @apply text-xs font-mono px-2 py-0.5 rounded-full bg-accent-muted text-accent border border-accent/20;
+  }
+
+  .btn-primary {
+    @apply px-6 py-3 bg-accent hover:bg-accent-hover text-white font-semibold rounded-lg transition-colors duration-200;
+  }
+
+  .btn-secondary {
+    @apply px-6 py-3 bg-transparent border border-border hover:border-accent text-text-primary hover:text-accent font-semibold rounded-lg transition-colors duration-200;
+  }
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,36 @@
+import type { Config } from 'tailwindcss';
+import { theme } from './src/config/theme';
+
+export default {
+  content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
+  theme: {
+    extend: {
+      colors: {
+        background: theme.colors.background,
+        surface: theme.colors.surface,
+        'surface-hover': theme.colors.surfaceHover,
+        border: theme.colors.surfaceBorder,
+        accent: theme.colors.accent,
+        'accent-hover': theme.colors.accentHover,
+        'accent-muted': theme.colors.accentMuted,
+        'text-primary': theme.colors.textPrimary,
+        'text-muted': theme.colors.textMuted,
+        'text-subtle': theme.colors.textSubtle,
+      },
+      fontFamily: {
+        sans: theme.fonts.sans.split(',').map((f: string) => f.trim()),
+        mono: theme.fonts.mono.split(',').map((f: string) => f.trim()),
+      },
+      animation: {
+        'fade-up': 'fadeUp 0.6s ease-out forwards',
+      },
+      keyframes: {
+        fadeUp: {
+          '0%':   { opacity: '0', transform: 'translateY(24px)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' },
+        },
+      },
+    },
+  },
+  plugins: [],
+} satisfies Config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "astro/tsconfigs/strict",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@config/*": ["src/config/*"],
+      "@components/*": ["src/components/*"],
+      "@layouts/*": ["src/layouts/*"]
+    }
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "framework": "astro"
+}


### PR DESCRIPTION
## Summary
                                                                                                                                                                                 
  - Full rebuild of `atreyanr.github.io` from the Academic Pages Jekyll                                                                                                          
    template to a modern Astro static site deployed on Vercel                                                                                                                    
  - Motivated by the need for a recruiter-facing portfolio that reflects a                                                                                                       
    Data Scientist's actual work — scroll-driven storytelling, interactive                                                                                                       
    skill visualization, and a design system inspired by Databricks/Docker                                                                                                       
  - All visual tokens live in one file (`src/config/theme.ts`) and all                                                                                                           
    personal data in another (`src/config/content.ts`) — changing the                                                                                                            
    accent color or adding a project never requires touching HTML                                                                                                                
                                                                                                                                                                                 
  ## Changes                                                                                                                                                                   
                                                                                                                                                                                 
  ### Configuration & Tooling                                                                                                                                                    
  - `package.json` — replaced Jekyll npm scripts with Astro dev/build/check
  - `astro.config.mjs` — Astro 4 with `@astrojs/tailwind` + `@astrojs/react` integrations, static output                                                                         
  - `tailwind.config.ts` — extends Tailwind with tokens imported from `theme.ts`                                                                                                 
  - `tsconfig.json` — strict Astro TypeScript config with path aliases                                                                                                           
  - `vercel.json` — Vercel build config (`astro build`, `dist/`)                                                                                                                 
  - `.nojekyll` — disables GitHub Pages Jekyll processing                                                                                                                        
  - `.gitignore` — adds `dist/` and `.astro/`                                                                                                                                    
                                                                                                                                                                                 
  ### Design System (`src/config/`, `src/styles/`)                                                                                                                             
  - `theme.ts` — color palette, font stacks, GSAP animation config, Three.js particle config                                                                                     
  - `content.ts` — name, bio, titles, stats, skills (with proficiency), projects, experience                                                                                     
  - `global.css` — Tailwind base + `.glass`, `.reveal`, `.tag`, `.btn-primary`, `.btn-secondary`                                                                                 
                                                                                                                                                                                 
  ### Layout Shell (`src/layouts/`, `src/components/layout/`)                                                                                                                    
  - `Layout.astro` — HTML shell, Inter + JetBrains Mono fonts, GSAP + ScrollTrigger registered globally on `window`                                                              
  - `Navbar.astro` — fixed glassmorphism nav, active route highlighting, mobile hamburger                                                                                        
  - `Footer.astro` — social links driven from `content.ts`, hidden when fields are empty                                                                                         
                                                                                                                                                                                 
  ### Home Page (`src/components/sections/`, `src/pages/index.astro`)                                                                                                            
  - `Hero.astro` — full-viewport Three.js particle mesh with mouse repulsion, typewriter cycling through three titles, two CTA buttons, scroll indicator                         
  - `About.astro` — bio + three animated stat counters (GSAP count-up on scroll)                                                                                                 
                                                                                                                                                                                 
  ### Inner Pages                                                                                                                                                                
  - `projects.astro` + `ProjectCard.astro` — filterable card grid with tag chips, hover overlay reveals full stack, featured badge, `md:col-span-2` for featured cards           
  - `skills.astro` + `SkillGraph.tsx` — D3 force-directed graph (React island, `client:only="react"`), four skill clusters (ML Models, Optimization, NLP/RAG, Data & SQL), hover 
  tooltips with proficiency bars                                                                                                                                                 
  - `experience.astro` + `Timeline.astro` — vertical timeline, GSAP scroll-draws the center line, cards slide in from alternating sides (mobile: always left)                    
  - `blog/index.astro` + `blog/[slug].astro` + `BlogCard.astro` — Astro content collections, draft filtering, prose styles for Markdown posts                                    
  - `resume.astro` — `<embed>` PDF viewer with download button and mobile fallback
                                                                               
  ## Testing                                                                                                                                                                   
                                                                                                                                                                                 
  - [ ] `npm run build` — verify 7 pages build with no errors                                                                                                                    
  - [ ] `npm run dev` — open http://localhost:4321, confirm Three.js hero renders with particles and mouse interaction
  - [ ] Scroll down to About — confirm stat counters animate                                                                                                                     
  - [ ] Visit `/skills` — confirm D3 force graph clusters render and tooltips work on hover                                                                                    
  - [ ] Visit `/experience` — scroll slowly, confirm center line draws and cards slide in                                                                                        
  - [ ] Visit `/projects` — click tag filter buttons, confirm cards show/hide                                                                                                  
  - [ ] Visit `/blog` — confirm hello-world post appears; click through to post page                                                                                             
  - [ ] Visit `/resume` — confirm PDF embed renders and download button works                                                                                                    
  - [ ] Resize to mobile — confirm hamburger menu appears and timeline cards all slide from left                                                                                 
                                                                                                                                                                                 
  ## Notes                                                                                                                                                                     
                                                                                                                                                                                 
  - Jekyll files (`_config.yml`, `_layouts/`, `_sass/`, etc.) are still present in the repo root — remove them once Vercel deployment is verified live                           
  - `public/resume.pdf` is a placeholder — replace with actual resume before going live
  - `content.ts` personal fields (`email`, `github`, `linkedin`, stats, projects, experience) are stubs — fill in before launch                                                  
  - The accent color (`#FF6B35`) and all other visual settings can be changed in `src/config/theme.ts` with zero HTML edits required                                             
                                                                                                                                                                                 
  ---